### PR TITLE
Improve HF integration

### DIFF
--- a/scene/hmr2_extension.py
+++ b/scene/hmr2_extension.py
@@ -150,7 +150,7 @@ class GaussianHMR2(HMR2):
         return output
 
 
-class GaussianHMRPredictor(nn.Module):
+class GaussianHMRPredictor(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/prosperolo/GST", license="bsd-3-clause"):
     def __init__(self, cfg, smpl_cfg):
         super().__init__()
         self.cfg = cfg


### PR DESCRIPTION
Hi @prosperolo, 

Thanks for this nice work! Niels here from HF.

I noticed you already use the 🤗 hub for loading the model, which is great! 

This PR aims to improve the integration by:

* adding `from_pretrained` and `push_to_hub` capabilities to the model
* making sure download numbers work for your model (similar to models in the Transformers library)

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from scene.hmr2_extension import load_hmr_predictor, GaussianHMRPredictor

# define model
model = load_hmr_predictor(...)

# equip with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("your-hf-username-or-org/your-model")

# reload
model = GaussianHMRPredictor.from_pretrained("your-hf-username-or-org/your-model")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub.

Would you be interested in this integration?

Kind regards,

Niels